### PR TITLE
Skeleton for deleting question without AJAX

### DIFF
--- a/app/controllers/index.rb
+++ b/app/controllers/index.rb
@@ -145,6 +145,40 @@ get '/finished' do
   erb :"complete"
 end
 
+# ++++++++++++++++++++++++++ QUESTIONS
+
+get '/questions/:id/edit' do
+  @question = Question.find(params[:id])
+  erb :"surveys/questions/edit"
+end
+
+put '/questions/:id' do
+  @question = Question.find(params[:id])
+  @question.update(params[:question])
+end
+
+delete '/questions/:id/delete' do
+  survey = Survey.find_by(question_id: params[:id])
+  Question.find(params[:id]).destroy
+  redirect '/#{survey.ref_code}'
+end
+# ++++++++++++++++++++++++++ ANSWERS
+get '/answers/:id/edit' do
+  @answer = Answer.find(params[:id])
+  erb :"surveys/answers/edit"
+end
+
+put '/answers/:id' do
+end
+
+delete '/answers/:id/delete' do
+  Answer.find(params[:id]).destroy
+  redirect '/#{survey.ref_code}'
+end
+
+
+
+
 # ++++++++++++++++++++++++++ LAST ROUTE
 get '/:ref_code' do
   @survey = Survey.find_by(ref_code: params[:ref_code])

--- a/app/views/surveys/answers/edit.erb
+++ b/app/views/surveys/answers/edit.erb
@@ -1,0 +1,5 @@
+<form action = "/answers/<%=@answer.id%>" method = "POST">
+  <input name="_method" type="hidden" value="PUT"/>
+  <label for="content">Question:</label>
+  <input id="answer_content" type="text" name="answer[content]" value="<%= @answer.content %>" size=60/>
+</form>

--- a/app/views/surveys/questions/edit.erb
+++ b/app/views/surveys/questions/edit.erb
@@ -1,0 +1,5 @@
+<form action = "/questions/<%=@question.id%>" method = "POST">
+  <input name="_method" type="hidden" value="PUT"/>
+  <label for="content">Question:</label>
+  <input id="question_content" type="text" name="question[content]" value="<%= @question.content %>" size=60/>
+</form>

--- a/app/views/surveys/show.erb
+++ b/app/views/surveys/show.erb
@@ -5,8 +5,11 @@
     <form name="responses" action="/surveys/<%=@survey.ref_code%>/responses" method="POST">
     <% @survey.questions.each do |question| %>
     <br>
-      <a href="#">Edit this Question</a>
-      <a href="#">Delete this Question</a>
+      <a href="/questions/<%=question.id%>/edit">Edit this Question</a>
+      <form action = "/questions/<%=question.id%>/delete" method = "POST">
+        <input name="_method" type="hidden" value="DELETE"/>
+        <input type ="submit" value = "DELETE"/>
+      </form>
       <br>
       <li><h2><%= question.content %></h2></li>
       <ol>
@@ -16,8 +19,11 @@
         <input id="response[<%= question.id  %>]" type="radio" name="response[<%= question.id %>]" value="<%= answer.id %>" text="<%= answer %>">
         <label for="response[<%= question.id  %>]"><%= answer.content %></label>
         <%if current_user == @survey.user%>
-          <a href="#">Edit This Answer</a>
-          <a href="#">Delete This Answer</a><br>
+          <a href="/answers/<%=answer.id%>/edit">Edit This Answer</a>
+        <form action = "/questions/<%=answer.id%>/delete" method = "POST">
+          <input name="_method" type="hidden" value="DELETE"/>
+          <input type ="submit" value = "DELETE"/>
+        </form>
         <%end%>
       <%end%>
       </ol>


### PR DESCRIPTION
we worked on setting up the edit and delete (questions and answer routes). We're running into an issue with the routes because we need to access the survey they are a part of. However, we think this is an issue that will disappear with the AJAX so we pushed this up so that @KaraAJC  can work off of these routes. (In the controller there is now a questions and answers section).
